### PR TITLE
Accept ::-formatted (but unrecognized) emoji

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,12 @@ if (queryEmoji) {
     if (searchEmoji) {
       emoji = searchEmoji.emoji;
     }
+    // Unknown emoji specified in query -- possibly custom! If it starts/finishes with `:`, pass it through as a raw
+    // string, since user may want to paste output into Slack (where the custom emoji is presumably supported).
+    // Otherwise, default to 👏.
+    if (/:.+:/.test(queryEmoji)) {
+      emoji = queryEmoji;
+    }
   }
 }
 


### PR DESCRIPTION
### Context

Currently, we fall back to 👏when we don't recognize an emoji specified in query params—e.g., http://clapinator.com/?emoji=:unknown:.

### Changes

This PR proposes that, when the unrecognized emoji is formatted `:like-this:`, we render it "raw," under the assumption that the user intends to copy–paste the output into Slack, where the unrecognized (presumably custom) emoji will "kick in."

Unrecognized emoji, no special formatting:
<img width="514" alt="Screen Shot 2019-12-13 at 5 14 14 PM" src="https://user-images.githubusercontent.com/6352327/70841057-06a17580-1dcc-11ea-84d2-b996b581732f.png">

Unrecognized emoji, `::` formatting:
<img width="522" alt="Screen Shot 2019-12-13 at 5 13 37 PM" src="https://user-images.githubusercontent.com/6352327/70841044-f2f60f00-1dcb-11ea-9f00-c782ce6df30c.png">

/cc @max-winderbaum @ShannonLCapper 